### PR TITLE
Restore original message of the day, before making in progress message

### DIFF
--- a/pleskdistup/actions/common.py
+++ b/pleskdistup/actions/common.py
@@ -70,6 +70,7 @@ To monitor the conversion progress in real time, run the '{path_to_util} --monit
 
     def _prepare_action(self) -> action.ActionResult:
         log.debug("Adding 'in progress' login message...")
+        motd.restore_ssh_login_message()
         motd.add_inprogress_ssh_login_message(self.in_progress_message)
         return action.ActionResult()
 


### PR DESCRIPTION
Since process has been started from scratch, we should remove previous in-progress message and fill it from the scratch