### PR TITLE
Work with postfix systemd service only if it exists

### DIFF
--- a/pleskdistup/actions/systemd.py
+++ b/pleskdistup/actions/systemd.py
@@ -113,7 +113,7 @@ class DisablePleskRelatedServicesDuringUpgrade(action.ActiveAction):
         # so we should choose the right smtp service, otherwise they will conflict
         if systemd.is_service_exists("qmail.service"):
             self.plesk_systemd_services.append("qmail.service")
-        else:
+        elif systemd.is_service_exists("postfix.service"):
             self.plesk_systemd_services.append("postfix.service")
 
     def _prepare_action(self) -> action.ActionResult:


### PR DESCRIPTION
Actually we could remove all SMTP servers from plesk instance by plesk installer. Or don't even install any at all. So we should not interact with postfix service, therwise systemctl will fail