### PR TITLE
Handle parce exceptions carefully on checking sslmng output

### DIFF
--- a/pleskdistup/actions/emails.py
+++ b/pleskdistup/actions/emails.py
@@ -32,6 +32,12 @@ class SetMinDovecotDhParamSize(action.ActiveAction):
         except json.JSONDecodeError:
             log.warn(f"Failed to parse plesk sslmng results: {proc.stdout}")
             return False
+        except KeyError as e:
+            log.warn(f"There is no parameter '{e}' in the sslmng output.")
+            return False
+        except Exception as e:
+            log.warn(f"Failed to check sslmng configuration for dovecot: {e}. Type is {type(e)}")
+            raise e
 
         return True
 


### PR DESCRIPTION
In some cases sslmng output could skip parameters for specific services. This situation is fine, so we should just skip the DH parameters increase action in this case.