### PR TITLE
Move Mailman systemd service operations to a separate action

### DIFF
--- a/pleskdistup/actions/grub.py
+++ b/pleskdistup/actions/grub.py
@@ -5,6 +5,7 @@ from pleskdistup.common import action, util
 
 DEBCONF_CMD = "/usr/bin/debconf-show"
 
+
 class AssertGrubInstallDeviceExists(action.CheckAction):
     def __init__(self) -> None:
         self.name = "check GRUB installation device exists"


### PR DESCRIPTION
We will now skip any interactions with the Mailman service if it is not active at the start of the conversion.
By default, mailman is not configured and the service will fail to start. Therefore, attempts to start it during the revert or finishing stage will also fail.