### PR TITLE
Allow 'mysqld' systemd service name as a service for plesk database

### DIFF
--- a/pleskdistup/common/src/plesk.py
+++ b/pleskdistup/common/src/plesk.py
@@ -216,7 +216,7 @@ class PleskDatabaseIsDown(Exception):
 def is_plesk_database_ready() -> bool:
     if mariadb.is_mariadb_installed():
         return systemd.is_service_active("mariadb")
-    return systemd.is_service_active("mysql")
+    return systemd.is_service_active("mysql") or systemd.is_service_active("mysqld")
 
 
 def get_from_plesk_database(query: str) -> typing.Optional[typing.List[str]]:


### PR DESCRIPTION
The MySQL installation from the community repository uses 'mysqld' as the systemd service name. Therefore, we should also support this name for the Plesk database service.