### PR TITLE
Add a function to extract critical risk factors from the leapp report

### DIFF
--- a/pleskdistup/common/src/dpkg.py
+++ b/pleskdistup/common/src/dpkg.py
@@ -138,7 +138,7 @@ def _exec_retry_when_locked(
 
     def process_stdout(line: str) -> None:
         if collect_stdout:
-            nonlocal stdout
+            nonlocal stdout  # noqa: F824
             stdout.append(line)
         log.info("stdout: {}".format(line.rstrip('\n')), to_stream=False)
 

--- a/pleskdistup/common/src/leapp_configs.py
+++ b/pleskdistup/common/src/leapp_configs.py
@@ -557,7 +557,7 @@ def _extract_leapp_report_inhibitors_from_txt(txt_report_path: str) -> typing.Li
 
     inhibitors: typing.List[str] = []
     with open(txt_report_path) as report_file:
-        current_risk_factor = []
+        current_risk_factor: typing.List[str] = []
         is_inhibitor = False
         for line in report_file:
             if line.startswith("Risk Factor: high (inhibitor)"):


### PR DESCRIPTION
These factors stops the conversion, so it's beneficial to have them in the output for easier investigation of the conversion failure.