### PR TITLE
Add pre-check for installable packages before dist-upgrade

### DIFF
--- a/pleskdistup/actions/packages.py
+++ b/pleskdistup/actions/packages.py
@@ -118,3 +118,21 @@ class AssertRepositorySubstitutionAvailable(action.CheckAction):
                 return False
 
         return True
+
+
+class AssertPackageAvailable(action.CheckAction):
+    """
+    Check if the package is available in the target repository.
+    """
+
+    def __init__(self, package_name: str, name: str = "asserting package available", recommendation: str = ""):
+        self.name = name
+        self.package_name = package_name
+        self.description = f"Package '{package_name}' is not available."
+        if recommendation:
+            self.description += f" {recommendation}"
+
+    def _do_check(self) -> bool:
+        if not packages.is_package_available(self.package_name):
+            return False
+        return True

--- a/pleskdistup/common/src/dpkg.py
+++ b/pleskdistup/common/src/dpkg.py
@@ -324,3 +324,22 @@ def get_repository_metafile_url(repository_url: str) -> str:
     :return: URL of the repository metafile
     """
     return repository_url.rstrip("/") + "/Release"
+
+
+def is_package_available(package_name: str) -> bool:
+    """
+    Check if the package is available in enabled repositories.
+    :param package_name: name of the package to check
+    :return: True if the package is available, False otherwise
+    """
+    cmd = ["/usr/bin/apt-cache", "show", package_name]
+    res = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    if res.returncode != 0:
+        log.debug(f"apt-cache show {package_name} failed with stdout: {res.stdout}, stderr: {res.stderr}")
+
+    return res.returncode == 0

--- a/pleskdistup/common/src/packages.py
+++ b/pleskdistup/common/src/packages.py
@@ -153,3 +153,18 @@ def get_repository_metafile_url(repository_url: str) -> str:
         return rpm.get_repository_metafile_url(repository_url)
     else:
         raise NotImplementedError(f"Unsupported distro {started_on}")
+
+
+def is_package_available(package_name: str) -> bool:
+    """
+    Check if the package could be installed on the system.
+    :param package_name: name of the package to check
+    :return: True if the package is available, False otherwise
+    """
+    started_on = dist.get_distro()
+    if started_on.deb_based:
+        return dpkg.is_package_available(package_name)
+    elif started_on.rhel_based:
+        return rpm.is_package_available(package_name)
+    else:
+        raise NotImplementedError(f"Unsupported distro {started_on}")

--- a/pleskdistup/common/src/rpm.py
+++ b/pleskdistup/common/src/rpm.py
@@ -409,3 +409,28 @@ def extract_gpgkey_from_rpm_database(
 
     os.remove(destination)
     return False
+
+
+def is_package_available(package_name: str) -> bool:
+    """
+    Check if the package is available in enabled repositories.
+    :param package_name: name of the package to check
+    :return: True if the package is available, False otherwise
+    """
+    cmd = ["/usr/bin/yum", "list", "available", package_name]
+    res = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+
+    # If the command returns 0, the package is available.
+    # If it returns 1, the package is not available.
+    # If it returns any other code, it means there was an error in yum itself.
+    if res.returncode != 0 and res.returncode != 1:
+        log.debug(
+            f"Command '{' '.join(cmd)}' failed with return code {res.returncode}. stdout: {res.stdout}, stderr: {res.stderr}"
+        )
+
+    return res.returncode == 0


### PR DESCRIPTION
Some dist-upgrade tools depend on additional packages. For example AlmaLinux leapp requires `dnf` package.