### PR TITLE
Add an action to check if SELinux httpd_can_network_connect is permanently disabled

### DIFF
--- a/pleskdistup/actions/common_checks.py
+++ b/pleskdistup/actions/common_checks.py
@@ -10,7 +10,7 @@ import typing
 import urllib.request
 from abc import abstractmethod
 
-from pleskdistup.common import action, log, files, packages, php, plesk, rpm, version
+from pleskdistup.common import action, log, files, packages, php, plesk, rpm, selinux, version
 
 
 class AssertNoRepositoryDuplicates(action.CheckAction):
@@ -889,3 +889,40 @@ class AssertAvailableSpaceForLocation(action.CheckAction):
 
         self.description = self.description.format(self._huminize_size(self.required_space), self.location, self._huminize_size(available_space))
         return False
+
+
+class AssertSelinuxHttpdCanNetworkConnect(action.CheckAction):
+    HTTPD_CAN_NETWORK_CONNECT: str = "httpd_can_network_connect"
+
+    selinux_config: str
+
+    def __init__(self, selinux_config: str = selinux.SELINUX_CONFIG_PATH) -> None:
+        self.selinux_config = selinux_config
+        self.name = "checking if SELinux allows httpd to connect to the network"
+        self.description = """SELinux is configured to run in enforcing mode in '{config}', but the '{boolean}' boolean is permanently disabled.
+\tWebmail will not be able to work after the conversion in this configuration: SELinux denies
+\tthe outgoing connections webmail relies on.
+\tTo proceed with the conversion, do one of the following:
+\t- allow the connections by calling 'setsebool -P {boolean} 1'
+\t- or disable SELinux by setting 'SELINUX=permissive' (or 'SELINUX=disabled') in '{config}'
+""".format(config=selinux_config, boolean=self.HTTPD_CAN_NETWORK_CONNECT)
+
+    def _do_check(self) -> bool:
+        mode = selinux.get_configured_mode(self.selinux_config)
+        log.debug(f"SELinux mode configured in {self.selinux_config!r} is {mode.value!r}")
+        if mode is not selinux.SelinuxMode.ENFORCING:
+            return True
+
+        # We should check persisted state for the boolean exactly, because
+        # the runtime state will be reset during reboot into new OS anyway
+        state = selinux.get_boolean_persisted_state(self.HTTPD_CAN_NETWORK_CONNECT)
+        if state is None:
+            log.warn(
+                f"Unable to determine the persisted value of the {self.HTTPD_CAN_NETWORK_CONNECT!r} "
+                "SELinux boolean, skipping the check. If the boolean is disabled, webmail will not "
+                "work after the conversion."
+            )
+            return True
+
+        log.debug(f"The persisted value of the {self.HTTPD_CAN_NETWORK_CONNECT!r} SELinux boolean is {state}")
+        return state

--- a/pleskdistup/common/src/__init__.py
+++ b/pleskdistup/common/src/__init__.py
@@ -16,6 +16,7 @@ from . import postgres
 from . import feedback
 from . import files
 from . import rpm
+from . import selinux
 from . import strings
 from . import systemd
 from . import util

--- a/pleskdistup/common/src/selinux.py
+++ b/pleskdistup/common/src/selinux.py
@@ -1,0 +1,81 @@
+# Copyright 2023-2026. WebPros International GmbH. All rights reserved.
+import enum
+import os
+import re
+import subprocess
+import typing
+
+from . import log
+
+SELINUX_CONFIG_PATH = "/etc/selinux/config"
+SEMANAGE_BIN_PATH = "/usr/sbin/semanage"
+
+
+class SelinuxMode(enum.Enum):
+    ENFORCING = "enforcing"
+    PERMISSIVE = "permissive"
+    DISABLED = "disabled"
+    UNKNOWN = "unknown"
+
+
+def get_configured_mode(config_path: str = SELINUX_CONFIG_PATH) -> SelinuxMode:
+    """
+    Return the SELinux mode selected in the configuration file, or SelinuxMode.UNKNOWN when it
+    cannot be determined: the file is absent or unreadable, holds no effective 'SELINUX='
+    assignment, or the assigned value is not one of the recognized modes. Commented-out
+    assignments are ignored and the first effective assignment wins, as in libselinux itself.
+    """
+    if not os.path.exists(config_path):
+        return SelinuxMode.UNKNOWN
+
+    with open(config_path, encoding="utf-8", errors="replace") as config:
+        for line in config:
+            line = line.strip()
+            if line.startswith("SELINUX="):
+                value = line.split("=", 1)[1].split("#", 1)[0].strip().strip("\"'").lower()
+                try:
+                    return SelinuxMode(value)
+                except ValueError:
+                    log.debug(f"Unexpected SELinux mode {value!r} is configured in {config_path!r}")
+                    return SelinuxMode.UNKNOWN
+
+    return SelinuxMode.UNKNOWN
+
+
+def get_boolean_persisted_state(boolean_name: str) -> typing.Optional[bool]:
+    """
+    Return the persisted (policy store) value of an SELinux boolean, or None when it cannot be
+    determined: the semanage utility is unavailable, it fails, or it does not list the boolean.
+    'semanage boolean -l' prints '<name> (<runtime> , <persisted>) <description>', so the
+    value we are after is the second one.
+    """
+    if not os.path.exists(SEMANAGE_BIN_PATH):
+        log.debug(f"Unable to read the {boolean_name!r} SELinux boolean: {SEMANAGE_BIN_PATH!r} does not exist")
+        return None
+
+    try:
+        output = subprocess.check_output(
+            [SEMANAGE_BIN_PATH, "boolean", "-l"],
+            universal_newlines=True, stderr=subprocess.DEVNULL,
+            # semanage renders the state columns through gettext, so on a localized host they
+            # would read '(выкл , выкл)' and never match. The locale is pinned to keep the
+            # output parsable. The environment is inherited rather than replaced, since
+            # semanage is a python script and may rely on the rest of it.
+            env=dict(os.environ, LC_ALL="C", LANG="C"),
+        )
+    except subprocess.SubprocessError as ex:
+        log.debug(f"Unable to read the {boolean_name!r} SELinux boolean: {ex}")
+        return None
+
+    # 'httpd_can_network_connect             (off  ,  off)  Allow httpd to ...'
+    #                                          ^runtime ^persisted
+    boolean_line_regex = re.compile(
+        r"^{name}\s+\((?:on|off)\s*,\s*(?P<persisted>on|off)\s*\)".format(name=re.escape(boolean_name))
+    )
+    for line in output.splitlines():
+        match = boolean_line_regex.match(line)
+        if match is not None:
+            return match.group("persisted") == "on"
+
+    log.debug(f"The {boolean_name!r} SELinux boolean is not listed by {SEMANAGE_BIN_PATH!r}")
+    return None

--- a/pleskdistup/common/tests/selinuxtests.py
+++ b/pleskdistup/common/tests/selinuxtests.py
@@ -1,0 +1,158 @@
+# Copyright 2023-2026. WebPros International GmbH. All rights reserved.
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+import unittest.mock
+
+import src.selinux as selinux
+
+
+class GetConfiguredModeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.temp_dir, "config")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _write_config(self, content):
+        with open(self.config_path, "w") as config:
+            config.write(content)
+
+    def test_enforcing(self):
+        self._write_config("""# This file controls the state of SELinux on the system.
+SELINUX=enforcing
+SELINUXTYPE=targeted
+""")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.ENFORCING)
+
+    def test_permissive(self):
+        self._write_config("SELINUX=permissive\nSELINUXTYPE=targeted\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.PERMISSIVE)
+
+    def test_disabled(self):
+        self._write_config("SELINUX=disabled\nSELINUXTYPE=targeted\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.DISABLED)
+
+    def test_mixed_case_value(self):
+        self._write_config("SELINUX=Enforcing\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.ENFORCING)
+
+    def test_value_with_trailing_whitespace_and_quotes(self):
+        self._write_config("SELINUX=\"enforcing\"   \n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.ENFORCING)
+
+    def test_commented_out_assignment_is_ignored(self):
+        self._write_config("""# SELINUX= can take one of these three values:
+#SELINUX=enforcing
+SELINUX=permissive
+""")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.PERMISSIVE)
+
+    def test_trailing_comment_is_ignored(self):
+        # libselinux matches the value by prefix, so it reads this as enforcing and the host
+        # really does boot enforcing - the check has to agree with it
+        self._write_config("SELINUX=enforcing # keep it strict\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.ENFORCING)
+
+    def test_trailing_comment_without_separating_space_is_ignored(self):
+        self._write_config("SELINUX=permissive#for now\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.PERMISSIVE)
+
+    def test_quoted_value_with_trailing_comment(self):
+        self._write_config("SELINUX=\"disabled\"  # no selinux here\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.DISABLED)
+
+    def test_value_that_is_only_a_comment(self):
+        self._write_config("SELINUX=# nothing assigned\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.UNKNOWN)
+
+    def test_first_effective_assignment_wins(self):
+        self._write_config("SELINUX=permissive\nSELINUX=enforcing\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.PERMISSIVE)
+
+    def test_empty_value(self):
+        self._write_config("SELINUX=\nSELINUXTYPE=targeted\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.UNKNOWN)
+
+    def test_unrecognized_value(self):
+        self._write_config("SELINUX=foo\nSELINUXTYPE=targeted\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.UNKNOWN)
+
+    def test_no_assignment_at_all(self):
+        self._write_config("# nothing useful here\nSELINUXTYPE=targeted\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.UNKNOWN)
+
+    def test_non_existent_file(self):
+        self.assertEqual(
+            selinux.get_configured_mode(os.path.join(self.temp_dir, "no_such_config")),
+            selinux.SelinuxMode.UNKNOWN,
+        )
+
+    def test_undecodable_bytes_do_not_raise(self):
+        with open(self.config_path, "wb") as config:
+            config.write(b"# r\xe9sum\xe9 of the admin\nSELINUX=enforcing\n")
+        self.assertEqual(selinux.get_configured_mode(self.config_path), selinux.SelinuxMode.ENFORCING)
+
+
+class GetBooleanPersistedStateTests(unittest.TestCase):
+    BOOLEAN_NAME = "httpd_can_network_connect"
+
+    SEMANAGE_OUTPUT_TEMPLATE = """SELinux boolean                State  Default Description
+
+abrt_anon_write                (off  ,  off)  Allow abrt to anon write
+httpd_can_network_connect      ({runtime}  ,  {persisted})  Allow httpd to can network connect
+httpd_can_network_connect_db   (off  ,  off)  Allow httpd to can network connect db
+"""
+
+    SEMANAGE_HEADER_ONLY_OUTPUT = """SELinux boolean                State  Default Description
+
+"""
+
+    def _get_state(self, output):
+        with unittest.mock.patch("src.selinux.os.path.exists", return_value=True):
+            with unittest.mock.patch("src.selinux.subprocess.check_output", return_value=output):
+                return selinux.get_boolean_persisted_state(self.BOOLEAN_NAME)
+
+    def test_runtime_on_persisted_on(self):
+        output = self.SEMANAGE_OUTPUT_TEMPLATE.format(runtime="on", persisted="on")
+        self.assertIs(self._get_state(output), True)
+
+    def test_runtime_on_persisted_off(self):
+        # A non-persistent 'setsebool' without '-P': the persisted value is what counts.
+        # assertIs, not assertFalse: None would mean the line was not parsed at all
+        output = self.SEMANAGE_OUTPUT_TEMPLATE.format(runtime="on", persisted="off")
+        self.assertIs(self._get_state(output), False)
+
+    def test_runtime_off_persisted_off(self):
+        output = self.SEMANAGE_OUTPUT_TEMPLATE.format(runtime="off", persisted="off")
+        self.assertIs(self._get_state(output), False)
+
+    def test_boolean_with_shared_prefix_does_not_match(self):
+        output = """SELinux boolean                State  Default Description
+
+httpd_can_network_connect_db   (on   ,  on)   Allow httpd to can network connect db
+"""
+        self.assertIsNone(self._get_state(output))
+
+    def test_header_only_output(self):
+        self.assertIsNone(self._get_state(self.SEMANAGE_HEADER_ONLY_OUTPUT))
+
+    def test_empty_output(self):
+        self.assertIsNone(self._get_state(""))
+
+    def test_semanage_is_missing(self):
+        with unittest.mock.patch("src.selinux.os.path.exists", return_value=False):
+            with unittest.mock.patch("src.selinux.subprocess.check_output") as check_output_mock:
+                self.assertIsNone(selinux.get_boolean_persisted_state(self.BOOLEAN_NAME))
+                check_output_mock.assert_not_called()
+
+    def test_semanage_call_fails(self):
+        with unittest.mock.patch("src.selinux.os.path.exists", return_value=True):
+            with unittest.mock.patch(
+                "src.selinux.subprocess.check_output",
+                side_effect=subprocess.CalledProcessError(1, "semanage"),
+            ):
+                self.assertIsNone(selinux.get_boolean_persisted_state(self.BOOLEAN_NAME))


### PR DESCRIPTION
In this case webmail will not work after the conversion is done, which could be considered a conversion-triggered problem. So we should prevent conversion in this case.